### PR TITLE
Add emote streak location preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ For example, if I wanted to add the "minStreak" and the "7tv" parameter, my new 
     - Sets the ending text for the emote streak
     - For no text, add an empty `emoteStreakText=` to the end of the URL
     - Defaults to `Streak!`
-
+-   emoteLocation=*(1 for bottom left, 2 for top left, 3 for top right, 4 for bottom right)*
+    - Sets the emoteStreak position
+    - Defaults to 1
 ---
 
 ## Development

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ const config = {
   showEmoteCooldown: Number(url.searchParams.get("showEmoteCooldown") || 6),
   showEmoteSizeMultiplier: Number(url.searchParams.get("showEmoteSizeMultiplier") || 1),
   minStreak: Number(url.searchParams.get("minStreak") || 5),
+  emoteLocation: Number(url.searchParams.get("emoteLocation") || 1),
   emoteStreakEndingText: url.searchParams.get("emoteStreakText")?.replace(/(<([^>]+)>)/gi, "") ?? "streak!",
   showEmoteCooldownRef: new Date(),
   streakCooldown: new Date().getTime(),
@@ -202,8 +203,27 @@ const streakEvent = () => {
   if (config.currentStreak.streak >= config.minStreak && config.streakEnabled) {
     $("#main").empty();
     $("#main").css("position", "absolute");
-    $("#main").css("top", "600");
-    $("#main").css("left", "35");
+
+    switch (config.emoteLocation) {
+      default:
+      case 1:
+        $("#main").css("top", "600");
+        $("#main").css("left", "35");
+        break;
+      case 2:
+        $("#main").css("bottom", "600");
+        $("#main").css("left", "35");
+        break;
+      case 3:
+        $("#main").css("bottom", "600");
+        $("#main").css("right", "35");
+        break;
+      case 4:
+        $("#main").css("top", "600");
+        $("#main").css("right", "35");
+        break;
+    }
+
 
     $("<img />", { src: config.currentStreak.url }).appendTo("#main");
     $("#main")


### PR DESCRIPTION
Adds an optional query parameter for specifying where on the screen the emote streak should appear.
**1 2 3 4** clock-wise. 

I followed the structure of the existing code.

Closes #6 