### PR TITLE
fix(showemote): Use correct size for random position

### DIFF
--- a/main.js
+++ b/main.js
@@ -156,7 +156,7 @@ const findUrlInEmotes = (emote) => {
   return null;
 };
 
-const getRandomCoords = () => [Math.floor(Math.random() * 720), Math.floor(Math.random() * 1280)];
+const getRandomCoords = () => [Math.floor(Math.random() * 1280), Math.floor(Math.random() * 720)];
 
 const showEmote = (message, rawMessage) => {
   if (config.showEmoteEnabled) {


### PR DESCRIPTION
`getRandomCoords` is being called through `const [x, y] = getRandomCoords();`, but the implementation uses [y, x]. The coordinates are swapped.

A x then y ordering is more human-natural, so the method implementation is fixed by swapping the two value calculations for x and y.