### PR TITLE
Fix showEmote positioning and dissolve need for epected render size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview:
 
-This project is an overlay that shows emote streaks on the bottom left of the page. **_(Page dimensions are 1280px x 720px)_**  
+This project is an overlay that shows emote streaks on the bottom left of the page.  
 It can also show emotes randomly on screen if a chatter does !showemote (*emote_name*)  
 *This overlay can be used in streaming software like OBS*   
 The emotes are taken from Twitch, FFZ, BTTV, and 7TV.

--- a/main.css
+++ b/main.css
@@ -1,6 +1,20 @@
+body {
+  margin: 0;
+}
 #world {
   color: #ffffff;
   font-size: 25px;
   font-family: "Comic Sans MS", cursive, sans-serif;
   text-shadow: -1.5px -1.5px 0 #000, 1.5px -1.5px 0 #000, -1.5px 1.5px 0 #000, 1.5px 1.5px 0 #000;
+}
+#showEmote {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+
+  display: grid;
+  grid-template-areas: ". . ." ". img ." ". . .";
+}
+#showEmote img {
+  grid-area: img;
 }

--- a/main.js
+++ b/main.js
@@ -262,16 +262,19 @@ const showEmoteEvent = (url) => {
     $("#showEmote").empty();
     const [x, y] = getRandomCoords();
     const emoteEl = $("#showEmote");
-    emoteEl.css("position", "absolute");
+    // left
     if (x < max_width / 2) {
-      emoteEl.css("left", x + "px");
+      emoteEl.css("grid-template-columns", `${x}px auto 1fr`);
+    // right
     } else {
-      emoteEl.css("right", (max_width - x) + "px");
+      emoteEl.css("grid-template-columns", `1fr auto ${max_width - x}px`);
     }
+    // top
     if (y < max_height / 2) {
-      emoteEl.css("top", y + "px");
+      emoteEl.css("grid-template-rows", `${y}px auto 1fr`);
+    // bottom
     } else {
-      emoteEl.css("bottom", (max_height - y) + "px");
+      emoteEl.css("grid-template-rows", `1fr auto ${max_height - y}px`);
     }
 
     $("<img />", {

--- a/main.js
+++ b/main.js
@@ -158,10 +158,6 @@ const findUrlInEmotes = (emote) => {
   return null;
 };
 
-const max_width = 1280;
-const max_height = 720;
-const getRandomCoords = () => [Math.floor(Math.random() * max_width), Math.floor(Math.random() * max_height)];
-
 const showEmote = (message, rawMessage) => {
   if (config.showEmoteEnabled) {
     const emoteUsedPos = rawMessage[4].startsWith("emotes=") ? 4 : 5;
@@ -253,6 +249,8 @@ const streakEvent = () => {
   }
 };
 
+const getRandomPosPercent = () => [Math.floor(Math.random() * 100), Math.floor(Math.random() * 100)];
+
 const showEmoteEvent = (url) => {
   const secondsDiff = (new Date().getTime() - new Date(config.showEmoteCooldownRef).getTime()) / 1000;
 
@@ -260,25 +258,25 @@ const showEmoteEvent = (url) => {
     config.showEmoteCooldownRef = new Date();
 
     $("#showEmote").empty();
-    const [x, y] = getRandomCoords();
+    const [x, y] = getRandomPosPercent();
     const emoteEl = $("#showEmote");
     let torigin = ''
     // left
-    if (x < max_width / 2) {
-      emoteEl.css("grid-template-columns", `${x}px auto 1fr`);
+    if (x <= 50) {
+      emoteEl.css("grid-template-columns", `${x}% auto 1fr`);
       torigin += 'left';
     // right
     } else {
-      emoteEl.css("grid-template-columns", `1fr auto ${max_width - x}px`);
+      emoteEl.css("grid-template-columns", `1fr auto ${100 - x}%`);
       torigin += 'right';
     }
     // top
-    if (y < max_height / 2) {
-      emoteEl.css("grid-template-rows", `${y}px auto 1fr`);
+    if (y <= 50) {
+      emoteEl.css("grid-template-rows", `${y}% auto 1fr`);
       torigin += ' top';
     // bottom
     } else {
-      emoteEl.css("grid-template-rows", `1fr auto ${max_height - y}px`);
+      emoteEl.css("grid-template-rows", `1fr auto ${100 - y}%`);
       torigin += ' bottom';
     }
 

--- a/main.js
+++ b/main.js
@@ -262,24 +262,29 @@ const showEmoteEvent = (url) => {
     $("#showEmote").empty();
     const [x, y] = getRandomCoords();
     const emoteEl = $("#showEmote");
+    let torigin = ''
     // left
     if (x < max_width / 2) {
       emoteEl.css("grid-template-columns", `${x}px auto 1fr`);
+      torigin += 'left';
     // right
     } else {
       emoteEl.css("grid-template-columns", `1fr auto ${max_width - x}px`);
+      torigin += 'right';
     }
     // top
     if (y < max_height / 2) {
       emoteEl.css("grid-template-rows", `${y}px auto 1fr`);
+      torigin += ' top';
     // bottom
     } else {
       emoteEl.css("grid-template-rows", `1fr auto ${max_height - y}px`);
+      torigin += ' bottom';
     }
 
     $("<img />", {
       src: url,
-      style: `transform: scale(${config.showEmoteSizeMultiplier}, ${config.showEmoteSizeMultiplier})`,
+      style: `transform: scale(${config.showEmoteSizeMultiplier}, ${config.showEmoteSizeMultiplier}); transform-origin: ${torigin};`,
     }).appendTo("#showEmote");
 
     gsap.to("#showEmote", 1, {


### PR DESCRIPTION
The three commits have elaborate descriptions.

The changeset:

* Fixes the left/right top/bottom positioning narrowing the reused `#showEmote` element (the opposite property is not cleared) and right and bottom alignment (setting right and bottom was setting limits rather than alignment)
* Fixes the emote size transform (when set to != default 1) leading to overflows / partial emotes depending on the random positioning
* Changes from an absolute to a relative showEmote positioning, dissolving the need for an expected page rendering size

The need for 720p page size is removed from the readme. Please confirm that the random positioning is the only expectation on the page size (despite being mentioned next to the streak display).\
*(`streakEvent` adjusts `#main` absolute position - which should continue to work fine for any page rendering size of reasonable size. There are no other code references to 720 or 1280.)*\
Should the page rendering size expectation remain in the readme?

I tested and verified with manual `showEmoteEvent` invocations.